### PR TITLE
Support `--output-path` when building documentation for multiple targets.

### DIFF
--- a/IntegrationTests/Tests/MixedTargetsTests.swift
+++ b/IntegrationTests/Tests/MixedTargetsTests.swift
@@ -99,7 +99,7 @@ final class MixedTargetsTests: ConcurrencyRequiringTestCase {
             .map(\.relativePath)
             .sorted()
         
-        XCTAssertEqual(combinedDataDirectoryContents, expectedExecutableDataFiles + expectedLibraryDataFiles)
+        XCTAssertEqual(combinedDataDirectoryContents, expectedCombinedDataFiles)
 #else
         XCTSkip("This test requires a Swift-DocC version that support the link-dependencies feature")
 #endif
@@ -129,12 +129,16 @@ final class MixedTargetsTests: ConcurrencyRequiringTestCase {
             .map(\.relativePath)
             .sorted()
         
-        XCTAssertEqual(combinedDataDirectoryContents, expectedExecutableDataFiles + expectedLibraryDataFiles)
+        XCTAssertEqual(combinedDataDirectoryContents, expectedCombinedDataFiles)
 #else
         XCTSkip("This test requires a Swift-DocC version that support the link-dependencies feature")
 #endif
     }
 }
+
+private let expectedCombinedDataFiles = [
+    "documentation.json"
+] + expectedExecutableDataFiles + expectedLibraryDataFiles
 
 private let expectedExecutableDataFiles = [
     "documentation/executable.json",

--- a/IntegrationTests/Tests/Utility/XCTestCase+swiftPackage.swift
+++ b/IntegrationTests/Tests/Utility/XCTestCase+swiftPackage.swift
@@ -155,7 +155,7 @@ struct SwiftInvocationResult {
             .components(separatedBy: .newlines)
             .reversed()
             // Gather the lines that list archive names
-            .prefix(while: { $0.hasSuffix(".doccarchive") })
+            .prefix(while: { !$0.hasPrefix("Generated ") })
             // Create absolute URLs for each archive
             .map { URL(fileURLWithPath: $0.trimmingCharacters(in: .whitespaces)) }
             // Restore the original output order

--- a/IntegrationTests/Tests/Utility/XCTestCase+swiftPackage.swift
+++ b/IntegrationTests/Tests/Utility/XCTestCase+swiftPackage.swift
@@ -148,14 +148,18 @@ struct SwiftInvocationResult {
     let exitStatus: Int
     
     var referencedDocCArchives: [URL] {
-        standardOutput
+        let reverseLogLines = standardOutput
             // Remove trailing empty lines
             .trimmingCharacters(in: .newlines)
             // The last few lines is a list of all the output archives
             .components(separatedBy: .newlines)
             .reversed()
-            // Gather the lines that list archive names
-            .prefix(while: { !$0.hasPrefix("Generated ") })
+        
+        guard let startOfArchiveOutputIndex = reverseLogLines.firstIndex(where: { $0.hasPrefix("Generated ") }) else {
+            return []
+        }
+        
+        return reverseLogLines[..<startOfArchiveOutputIndex]
             // Create absolute URLs for each archive
             .map { URL(fileURLWithPath: $0.trimmingCharacters(in: .whitespaces)) }
             // Restore the original output order

--- a/Plugins/SharedPackagePluginExtensions/Target+doccArchiveOutputPath.swift
+++ b/Plugins/SharedPackagePluginExtensions/Target+doccArchiveOutputPath.swift
@@ -1,15 +1,24 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 import PackagePlugin
+import Foundation
 
 extension Target {
     func doccArchiveOutputPath(in context: PluginContext) -> String {
-        return context.pluginWorkDirectory.appending("\(name).doccarchive").string
+        context.pluginWorkDirectory.appending(archiveName).string
+    }
+    
+    func dependencyDocCArchiveOutputPath(in context: PluginContext) -> String {
+        context.pluginWorkDirectory.appending("dependencies").appending(archiveName).string
+    }
+    
+    private var archiveName: String {
+        "\(name).doccarchive"
     }
 }

--- a/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
+++ b/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
@@ -165,7 +165,6 @@ import PackagePlugin
         let buildGraphRunner = DocumentationBuildGraphRunner(buildGraph: .init(targets: swiftSourceModuleTargets))
         let intermediateDocumentationArchives = try buildGraphRunner.perform(performBuildTask)
             .compactMap { $0 }
-            .sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
         
         guard let firstIntermediateArchive = intermediateDocumentationArchives.first else {
             print("Didn't generate any documentation archives.")
@@ -180,7 +179,9 @@ import PackagePlugin
                 let outputDirectory = parsedArguments.outputDirectory ?? defaultPluginOutputDirectory
                 try? FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: false)
                 
-                let archiveLocations = intermediateDocumentationArchives.map { outputDirectory.appendingPathComponent($0.lastPathComponent, isDirectory: true) }
+                let archiveLocations = intermediateDocumentationArchives
+                    .map { outputDirectory.appendingPathComponent($0.lastPathComponent, isDirectory: true) }
+                
                 for (from, to) in zip(intermediateDocumentationArchives, archiveLocations) {
                     try? FileManager.default.removeItem(at: to)
                     try FileManager.default.moveItem(at: from, to: to)
@@ -188,7 +189,7 @@ import PackagePlugin
                 
                 print("""
                 Generated \(archiveLocations.count) documentation archives:
-                  \(archiveLocations.map(\.standardizedFileURL.path).joined(separator: "\n  "))
+                  \(archiveLocations.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }).map(\.standardizedFileURL.path).joined(separator: "\n  "))
                 """)
             } else {
                 let archiveLocation: URL

--- a/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
+++ b/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
@@ -150,8 +150,6 @@ import PackagePlugin
             let process = try Process.run(doccExecutableURL, arguments: doccArguments)
             process.waitUntilExit()
             
-            let conversionDuration = conversionStartTime.distance(to: .now())
-            
             // Check whether the `docc convert` invocation was successful.
             if process.terminationReason == .exit && process.terminationStatus == 0 {
                 print("Finished building documentation for '\(target.name)' (\(conversionStartTime.distance(to: .now()).descriptionInSeconds))")

--- a/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
+++ b/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
@@ -196,6 +196,11 @@ import PackagePlugin
         mergeCommandArguments.append(contentsOf: documentationArchives.map(\.standardizedFileURL.path))
         mergeCommandArguments.append(contentsOf: [DocCArguments.outputPath.preferred, combinedArchiveOutput.path])
         
+        if let doccFeatures, doccFeatures.contains(.synthesizedLandingPageName) {
+            mergeCommandArguments.append(contentsOf: [DocCArguments.synthesizedLandingPageName.preferred, context.package.displayName])
+            mergeCommandArguments.append(contentsOf: [DocCArguments.synthesizedLandingPageKind.preferred, "Package"])
+        }
+        
         // Remove the combined archive if it already exists
         try? FileManager.default.removeItem(at: combinedArchiveOutput)
         

--- a/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
+++ b/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
@@ -42,20 +42,14 @@ import PackagePlugin
         let verbose = parsedArguments.pluginArguments.verbose
         let isCombinedDocumentationEnabled = parsedArguments.pluginArguments.enableCombinedDocumentation
         
-        let doccFeatures: DocCFeatures?
-        // Only read and decode the features file if something is going to check those flags.
-        if isCombinedDocumentationEnabled {
-            doccFeatures = try? DocCFeatures(doccExecutable: doccExecutableURL)
-            guard doccFeatures?.contains(.linkDependencies) == true else {
-                // The developer uses the combined documentation plugin flag with a DocC version that doesn't support combined documentation.
-                Diagnostics.error("""
-                Unsupported use of '\(DocumentedFlag.enableCombinedDocumentation.names.preferred)'. \
-                DocC version at '\(doccExecutableURL.path)' doesn't support combined documentation.
-                """)
-                return
-            }
-        } else {
-            doccFeatures = nil
+        let doccFeatures = try? DocCFeatures(doccExecutable: doccExecutableURL)
+        if isCombinedDocumentationEnabled, doccFeatures?.contains(.linkDependencies) == false {
+            // The developer uses the combined documentation plugin flag with a DocC version that doesn't support combined documentation.
+            Diagnostics.error("""
+            Unsupported use of '\(DocumentedFlag.enableCombinedDocumentation.names.preferred)'. \
+            DocC version at '\(doccExecutableURL.path)' doesn't support combined documentation.
+            """)
+            return
         }
         
 #if swift(>=5.7)

--- a/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
+++ b/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
@@ -71,7 +71,8 @@ import PackagePlugin
         // An inner function that defines the work to build documentation for a given target.
         func performBuildTask(_ task: DocumentationBuildGraph<SwiftSourceModuleTarget>.Task) throws -> URL? {
             let target = task.target
-            print("Generating documentation for '\(target.name)'...")
+            print("Extracting symbol information for '\(target.name)'...")
+            let symbolGraphGenerationStartTime = DispatchTime.now()
             
             let symbolGraphs = try packageManager.doccSymbolGraphs(
                 for: target,
@@ -101,6 +102,8 @@ import PackagePlugin
                 return nil
             }
             
+            print("Finished extracting symbol information for '\(target.name)'. (\(symbolGraphGenerationStartTime.distance(to: .now()).descriptionInSeconds))")
+            
             // Construct the output path for the generated DocC archive
             let archiveOutputPath: String
             let dependencyArchivePaths: [String]
@@ -117,7 +120,7 @@ import PackagePlugin
             }
             
             if verbose {
-                print("docc archive output path: '\(doccArchiveOutputPath)'")
+                print("documentation archive output path: '\(archiveOutputPath)'")
             }
             
             // Use the parsed arguments gathered earlier to generate the necessary
@@ -139,7 +142,7 @@ import PackagePlugin
                 print("docc invocation: '\(doccExecutableURL.path) \(arguments)'")
             }
             
-            print("Converting documentation...")
+            print("Building documentation for '\(target.name)'...")
             let conversionStartTime = DispatchTime.now()
             
             // Run `docc convert` with the generated arguments and wait until the process completes
@@ -150,7 +153,7 @@ import PackagePlugin
             
             // Check whether the `docc convert` invocation was successful.
             if process.terminationReason == .exit && process.terminationStatus == 0 {
-                print("Conversion complete! (\(conversionDuration.descriptionInSeconds))")
+                print("Finished building documentation for '\(target.name)' (\(conversionStartTime.distance(to: .now()).descriptionInSeconds))")
             } else {
                 Diagnostics.error("'docc convert' invocation failed with a nonzero exit code: '\(process.terminationStatus)'")
             }

--- a/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
+++ b/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
@@ -111,7 +111,7 @@ import PackagePlugin
             doccCatalogPath: target.doccCatalogPath,
             targetName: target.name,
             symbolGraphDirectoryPath: symbolGraphs.unifiedSymbolGraphsDirectory.path,
-            outputPath: target.doccArchiveOutputPath(in: context)
+            outputPath: parsedArguments.outputDirectory?.path ?? target.doccArchiveOutputPath(in: context)
         )
         
         if verbose {

--- a/Sources/SwiftDocCPluginUtilities/BuildGraph/DocumentationBuildGraphRunner.swift
+++ b/Sources/SwiftDocCPluginUtilities/BuildGraph/DocumentationBuildGraphRunner.swift
@@ -19,7 +19,6 @@ struct DocumentationBuildGraphRunner<Target: DocumentationBuildGraphTarget> {
     func perform<Result>(_ work: @escaping Work<Result>) throws -> [Result] {
         // Create a serial queue to perform each documentation build task
         let queue = OperationQueue()
-        queue.maxConcurrentOperationCount = 1
         
         // Operations can't raise errors. Instead we catch the error from 'performBuildTask(_:)'
         // and cancel the remaining tasks.

--- a/Sources/SwiftDocCPluginUtilities/DocCFeatures.swift
+++ b/Sources/SwiftDocCPluginUtilities/DocCFeatures.swift
@@ -84,4 +84,7 @@ extension DocCFeatures.Feature {
     
     /// DocC supports grouping overloaded symbols.
     static let overloads = DocCFeatures.Feature(name: "overloads")
+        
+    /// DocC supports specifying the display name and kind of the synthesized landing page for combined archive.
+    static let synthesizedLandingPageName = DocCFeatures.Feature(name: "synthesized-landing-page-name")
 }

--- a/Sources/SwiftDocCPluginUtilities/ParsedArguments.swift
+++ b/Sources/SwiftDocCPluginUtilities/ParsedArguments.swift
@@ -193,4 +193,18 @@ enum DocCArguments {
     static let externalLinkDependency = CommandLineArgument.Names(
         preferred: "--dependency"
     )
+    
+    /// A DocC flag for the "merge" command that specifies a custom display name for the synthesized landing page.
+    ///
+    /// The plugin defines this name so that it can specify the package name as the display name of the default landing page when building combined documentation for multiple targets.
+    static let synthesizedLandingPageName = CommandLineArgument.Names(
+        preferred: "--synthesized-landing-page-name"
+    )
+    
+    /// A DocC flag for the "merge" command that specifies a custom kind for the synthesized landing page.
+    ///
+    /// The plugin defines this name so that it can specify "Package" as the kind of the default landing page when building combined documentation for multiple targets.
+    static let synthesizedLandingPageKind = CommandLineArgument.Names(
+        preferred: "--synthesized-landing-page-kind"
+    )
 }

--- a/Sources/SwiftDocCPluginUtilities/ParsedArguments.swift
+++ b/Sources/SwiftDocCPluginUtilities/ParsedArguments.swift
@@ -23,6 +23,8 @@ struct ParsedArguments {
         pluginArguments      = .init(extractingFrom: &arguments)
         symbolGraphArguments = .init(extractingFrom: &arguments)
         
+        assert(arguments.extractOption(named: DocCArguments.outputPath).isEmpty,
+               "There shouldn't be any output path argument left in the remaining DocC arguments.")
         self.arguments = arguments
     }
     
@@ -108,8 +110,6 @@ struct ParsedArguments {
         arguments.insertIfMissing(.option(DocCArguments.fallbackBundleIdentifier, value: targetName))
         
         arguments.insertIfMissing(.option(DocCArguments.additionalSymbolGraphDirectory, value: symbolGraphDirectoryPath))
-        
-        assert(arguments.extractOption(named: DocCArguments.outputPath).isEmpty,"The plugin arguments should have extracted the output path.")
         arguments.insertIfMissing(.option(DocCArguments.outputPath, value: outputPath))
         
         if pluginArguments.enableCombinedDocumentation {

--- a/Tests/SwiftDocCPluginUtilitiesTests/ParsedArgumentsTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/ParsedArgumentsTests.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -164,6 +164,7 @@ final class ParsedArgumentsTests: XCTestCase {
         let argumentsWithOutputPath = ParsedArguments(
             ["--output-path", "/my/custom/output-path"]
         )
+        XCTAssertEqual(argumentsWithOutputPath.outputDirectory?.path, "/my/custom/output-path")
         
         XCTAssertEqual(
             argumentsWithOutputPath.doccArguments(
@@ -176,11 +177,11 @@ final class ParsedArgumentsTests: XCTestCase {
             ),
             [
                 "convert",
-                "--output-path", "/my/custom/output-path",
                 "--emit-lmdb-index",
                 "--fallback-display-name", "MyTarget",
                 "--fallback-bundle-identifier", "MyTarget",
                 "--additional-symbol-graph-dir", "/my/symbol-graph",
+                "--output-path", "/my/output-path",
             ]
         )
     }
@@ -212,7 +213,7 @@ final class ParsedArgumentsTests: XCTestCase {
             ]
         )
         
-        let argumentsWithAllRequiredOptions = ParsedArguments(
+        let argumentsWithFallbackInfoAndOutputPath = ParsedArguments(
             [
                 "--fallback-display-name", "custom-display-name",
                 "--fallback-bundle-identifier", "custom-bundle-identifier",
@@ -220,9 +221,10 @@ final class ParsedArgumentsTests: XCTestCase {
                 "--output-path", "/my/custom/output-path",
             ]
         )
+        XCTAssertEqual(argumentsWithFallbackInfoAndOutputPath.outputDirectory?.path, "/my/custom/output-path")
         
         XCTAssertEqual(
-            argumentsWithAllRequiredOptions.doccArguments(
+            argumentsWithFallbackInfoAndOutputPath.doccArguments(
                 action: .convert,
                 targetKind: .library,
                 doccCatalogPath: nil,
@@ -235,8 +237,8 @@ final class ParsedArgumentsTests: XCTestCase {
                 "--fallback-display-name", "custom-display-name",
                 "--fallback-bundle-identifier", "custom-bundle-identifier",
                 "--additional-symbol-graph-dir", "/my/custom/symbol-graph",
-                "--output-path", "/my/custom/output-path",
                 "--emit-lmdb-index",
+                "--output-path", "/my/output-path",
             ]
         )
     }
@@ -288,12 +290,11 @@ final class ParsedArgumentsTests: XCTestCase {
             ]
         )
         
-        let disableIndexingWithCustomOutputArguments = ParsedArguments(
-            [
-                "--disable-indexing",
-                "--output-path", "/custom/output-path"
-            ]
-        )
+        let disableIndexingWithCustomOutputArguments = ParsedArguments([
+            "--disable-indexing",
+            "--output-path", "/custom/output-path"
+        ])
+        XCTAssertEqual(disableIndexingWithCustomOutputArguments.outputDirectory?.path, "/custom/output-path")
         
         XCTAssertEqual(
             disableIndexingWithCustomOutputArguments.doccArguments(
@@ -307,10 +308,10 @@ final class ParsedArgumentsTests: XCTestCase {
             [
                 "convert",
                 "/my/catalog.docc",
-                "--output-path", "/custom/output-path",
                 "--fallback-display-name", "MyTarget",
                 "--fallback-bundle-identifier", "MyTarget",
                 "--additional-symbol-graph-dir", "/my/symbol-graph",
+                "--output-path", "/my/output-path",
             ]
         )
     }
@@ -341,7 +342,7 @@ final class ParsedArgumentsTests: XCTestCase {
             ]
         )
         
-        let argumentsWithMixOfRequiredAndOptional = ParsedArguments(
+        let argumentsWithOutputPath = ParsedArguments(
             [
                 "--transform-for-static-hosting",
                 "--port", "1802",
@@ -350,9 +351,10 @@ final class ParsedArgumentsTests: XCTestCase {
                 "--output-path", "/my/custom/output-path",
             ]
         )
+        XCTAssertEqual(argumentsWithOutputPath.outputDirectory?.path, "/my/custom/output-path")
         
         XCTAssertEqual(
-            argumentsWithMixOfRequiredAndOptional.doccArguments(
+            argumentsWithOutputPath.doccArguments(
                 action: .preview,
                 targetKind: .library,
                 doccCatalogPath: "/my/catalog.docc",
@@ -367,10 +369,10 @@ final class ParsedArgumentsTests: XCTestCase {
                 "--port", "1802",
                 "--analyze",
                 "--fallback-display-name", "custom-display-name",
-                "--output-path", "/my/custom/output-path",
                 "--emit-lmdb-index",
                 "--fallback-bundle-identifier", "MyTarget",
                 "--additional-symbol-graph-dir", "/my/symbol-graph",
+                "--output-path", "/my/output-path",
             ]
         )
     }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Support passing a custom `--output-path` value when building documentation for multiple targets.

This is technically unrelated to support for combined documentation archives, but it's more likely that developers will pass a custom output path when building combined documentation for multiple targets.

I implemented this PR in steps:
- First https://github.com/swiftlang/swift-docc-plugin/pull/89/commits/e66ee31902270dc48b3cfeb505ee16ebd24bfbe8 added support for `--output-path` only when building combined documentation.
- Then https://github.com/swiftlang/swift-docc-plugin/pull/89/commits/39d886c10f2bc4deb0f9a077e1f8ae6bb3f0a43a extended that support to non-combined documentation builds as well. 

  This is technically a change in behavior—each target will output in a subdirectory of the specified output path. However, I considered the old behavior incorrect and not worth preserving because it was broken—each target wrote over the previous target's output, resulting in only one target's output.


Additionally, this PR makes the following changes
- https://github.com/swiftlang/swift-docc-plugin/pull/89/commits/78fef3e93b18cc58ddf8888c209acc8b966e6f8a conditionally customizes the synthesized landing page using https://github.com/swiftlang/swift-docc/pull/1011
- https://github.com/swiftlang/swift-docc-plugin/pull/89/commits/3aeb6751da007ecc6c7eb9b8402f71c4135b3ed9 Refines the command output to add more information to the build tasks and print the resulting archive paths the same when building one target, many targets, or a combined archive.
- https://github.com/swiftlang/swift-docc-plugin/pull/89/commits/099fed3dc133783ea45cb961c96e080c9f0b4c03 Enables task parallelism when building documentation for more than one target
- https://github.com/swiftlang/swift-docc-plugin/pull/89/commits/1df6bb8b76cb2277639f3a48b440a0cc3bb96d3c adds two additional integration tests that verifies building combined documentation with and without a custom output path.

## Dependencies

This builds on top of #87 and #88. The new changes in this PR start with https://github.com/swiftlang/swift-docc-plugin/commit/e66ee31902270dc48b3cfeb505ee16ebd24bfbe8 and onwards. You can see [that subset of the diff here](https://github.com/swiftlang/swift-docc-plugin/pull/89/files/fb1c2950947095a94d247e446ed87c9671dfd444..099fed3dc133783ea45cb961c96e080c9f0b4c03).

Additionally, this PR conditionally uses some new functionality in https://github.com/swiftlang/swift-docc/pull/1011. 

## Testing

There are 3 behaviors to test in this PR
 - building documentation for one target with a custom output path
 - building documentation for multiple targets with a custom output path
 - building combined documentation  with a custom output path

Note that in all cases you need to disable package sandboxing to use a custom output path.

You can use the package plugin repo itself to test this. 

### Single target

Build documentation for one target with a custom output path
```sh
swift package \
  --disable-sandbox \
  generate-documentation \
  --target Snippets \
  --output-path MyOutputDir
```

After the build succeeds, the "MyOutputDir" directory should contain the _content_ of the Snippets target's documentation. 

### Multiple targets

Build documentation for two (or more) targets with a custom output path
```sh
swift package \
  --disable-sandbox \
  generate-documentation \
  --target Snippets \
  --target SwiftDocCPlugin \
  --output-path MyOutputDir
```

After the build succeeds, the "MyOutputDir" directory should contain the two subdirectories named "Snippets.doccarchive" and "SwiftDocCPlugin.doccarchive" that each contain that target's documentation.

### Combined targets

Build combined documentation for two (or more) targets with a custom output path
```sh
swift package \
  --disable-sandbox \
  generate-documentation \
  --target Snippets \
  --target SwiftDocCPlugin \
  --enable-experimental-combined-documentation \
  --output-path MyOutputDir
```

After the build succeeds, the "MyOutputDir" directory should contain the _content_ of the combined documentation archive. 

The plugin only prints the combined archives's output path. It doesn't print the individual target's output paths, even though they were built to produce the combined archive.


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ Not applicable.
