### PR TITLE
Disable integration tests that fail because of rdar://134406349

### DIFF
--- a/IntegrationTests/Tests/SnippetDocumentationGenerationTests.swift
+++ b/IntegrationTests/Tests/SnippetDocumentationGenerationTests.swift
@@ -44,6 +44,9 @@ final class SnippetDocumentationGenerationTests: ConcurrencyRequiringTestCase {
     }
 
     func testPreviewDocumentationWithSnippets() throws {
+#if os(macOS)
+        throw XCTSkip("Skipping integration tests due to rdar://134406349")
+#else
         let outputDirectory = try temporaryDirectory().appendingPathComponent("output")
 
         let port = try getAvailablePort()
@@ -102,5 +105,6 @@ final class SnippetDocumentationGenerationTests: ConcurrencyRequiringTestCase {
 
         // Send an interrupt to the SwiftPM parent process
         process.interrupt()
+#endif
     }
 }

--- a/IntegrationTests/Tests/SwiftDocCPreviewTests.swift
+++ b/IntegrationTests/Tests/SwiftDocCPreviewTests.swift
@@ -11,6 +11,9 @@ import XCTest
 
 final class SwiftDocCPreview: ConcurrencyRequiringTestCase {
     func testRunPreviewServerOnSamePortRepeatedly() throws {
+#if os(macOS)
+        throw XCTSkip("Skipping integration tests due to rdar://134406349")
+#else
         // Because only a single server can bind to a given port at a time,
         // this test ensures that the preview server running in the `docc`
         // process exits when the an interrupt is sent to the `SwiftPM` process.
@@ -110,5 +113,6 @@ final class SwiftDocCPreview: ConcurrencyRequiringTestCase {
             // Send an interrupt to the SwiftPM parent process
             process.interrupt()
         }
+#endif
     }
 }

--- a/IntegrationTests/Tests/Utility/XCTestCase+swiftPackage.swift
+++ b/IntegrationTests/Tests/Utility/XCTestCase+swiftPackage.swift
@@ -96,15 +96,20 @@ extension XCTestCase {
         }
 
         return try processQueue.sync {
-            let standardOutputString = String(data: standardOutputData, encoding: .utf8)
-            let standardErrorString = String(data: standardErrorData, encoding: .utf8)
+            let standardOutputString = String(data: standardOutputData, encoding: .utf8) ?? ""
+            let standardErrorString = String(data: standardErrorData, encoding: .utf8) ?? ""
 
+            
+            if process.terminationStatus != 0, standardErrorString.contains("<unknown>:0: error: unknown argument: ") {
+                throw XCTSkip("Skipping integration tests due to rdar://134406349")
+            }
+            
             return SwiftInvocationResult(
                 workingDirectory: directoryURL,
                 swiftExecutable: try swiftExecutableURL,
                 arguments: arguments.map(\.description),
-                standardOutput: standardOutputString ?? "",
-                standardError: standardErrorString ?? "",
+                standardOutput: standardOutputString ,
+                standardError: standardErrorString,
                 exitStatus: Int(process.terminationStatus)
             )
         }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This skips any integration test that fail because of rdar://134406349:

```
<unknown>:0: error: unknown argument: '-Xlinker'
<unknown>:0: error: unknown argument: '-rpath'
<unknown>:0: error: unknown argument: '-Xlinker'
```

See https://github.com/swiftlang/swift-docc-plugin/pull/88#issuecomment-2301554564

If we merge this—to unblock current PRs—we will open another PR that reverts this so that we can check when a fix is available in the CI.

## Dependencies

None.

## Testing

None. If the tests pass in the CI, then we know that this works.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~ 
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ Not applicable
