### PR TITLE
Avoid using `NSLock.withLock` because Linux doesn't support it before Swift 6.0

### DIFF
--- a/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
+++ b/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
@@ -12,7 +12,7 @@ import PackagePlugin
 /// Generating symbol graphs is the only task that can't run in parallel.
 ///
 /// We serialize its execution to support build concurrency for the other tasks.
-private let symbolGraphGenerationLock = NSLock()
+private let symbolGraphGenerationLock = Lock()
 
 extension PackageManager {
     struct DocCSymbolGraphResult {

--- a/Sources/SwiftDocCPluginUtilities/BuildGraph/DocumentationBuildGraphRunner.swift
+++ b/Sources/SwiftDocCPluginUtilities/BuildGraph/DocumentationBuildGraphRunner.swift
@@ -22,7 +22,7 @@ struct DocumentationBuildGraphRunner<Target: DocumentationBuildGraphTarget> {
         
         // Operations can't raise errors. Instead we catch the error from 'performBuildTask(_:)'
         // and cancel the remaining tasks.
-        let resultLock = NSLock()
+        let resultLock = Lock()
         var caughtError: Error?
         var results: [Result] = []
         

--- a/Sources/SwiftDocCPluginUtilities/Lock.swift
+++ b/Sources/SwiftDocCPluginUtilities/Lock.swift
@@ -1,0 +1,24 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+import Foundation
+
+/// A wrapper around NSLock.
+///
+/// This type exist to offer an alternative to `NSLock.withLock` on Linux before Swift 6.0.
+struct Lock {
+    private let innerLock = NSLock()
+    
+    func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+        // Use `lock()` and `unlock()` because Linux doesn't support `NSLock.withLock` before Swift 6.0
+        innerLock.lock()
+        defer { innerLock.unlock() }
+        
+        return try body()
+    }
+}

--- a/Tests/SwiftDocCPluginUtilitiesTests/DocumentationBuildGraphRunnerTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/DocumentationBuildGraphRunnerTests.swift
@@ -233,7 +233,7 @@ private extension DocumentationBuildGraphRunner {
         performing work: @escaping Work<TaskResult>
     ) -> (processedTargets: [TaskStatus], result: Result<[TaskResult], any Error>) {
         var processedTargets: [TaskStatus] = []
-        let lock = NSLock()
+        let lock = Lock()
         
         let result = Swift.Result(catching: {
             try self.perform { task in


### PR DESCRIPTION
… Swift 6.0

Bug/issue #, if applicable: https://github.com/swiftlang/swift-docc-plugin/issues/92

## Summary

This fixes a build error on Linux before Swift 6.0

## Dependencies

None

## Testing

Build on Linux with Swift 5.10

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
