### PR TITLE
Allow clang source module targets to be documented using the plugin

### DIFF
--- a/Plugins/SharedPackagePluginExtensions/ArgumentExtractor+extractSpecifiedTargets.swift
+++ b/Plugins/SharedPackagePluginExtensions/ArgumentExtractor+extractSpecifiedTargets.swift
@@ -90,15 +90,15 @@ extension ArgumentExtractor {
                 )
             }
             
-            guard let swiftSourceModuleTarget = target as? SourceModuleTarget else {
+            guard let sourceModuleTarget = target as? SourceModuleTarget else {
                 throw ArgumentParsingError.targetIsNotSourceModule(specifiedTarget)
             }
             
-            guard swiftSourceModuleTarget.kind != .test else {
+            guard sourceModuleTarget.kind != .test else {
                 throw ArgumentParsingError.testTarget(specifiedTarget)
             }
             
-            return swiftSourceModuleTarget
+            return sourceModuleTarget
         }
         
         return productTargets + targets

--- a/Plugins/SharedPackagePluginExtensions/ArgumentExtractor+extractSpecifiedTargets.swift
+++ b/Plugins/SharedPackagePluginExtensions/ArgumentExtractor+extractSpecifiedTargets.swift
@@ -48,11 +48,11 @@ enum ArgumentParsingError: LocalizedError, CustomStringConvertible {
 }
 
 extension ArgumentExtractor {
-    mutating func extractSpecifiedTargets(in package: Package) throws -> [SwiftSourceModuleTarget] {
+    mutating func extractSpecifiedTargets(in package: Package) throws -> [SourceModuleTarget] {
         let specifiedProducts = extractOption(named: "product")
         let specifiedTargets = extractOption(named: "target")
         
-        let productTargets = try specifiedProducts.flatMap { specifiedProduct -> [SwiftSourceModuleTarget] in
+        let productTargets = try specifiedProducts.flatMap { specifiedProduct -> [SourceModuleTarget] in
             let product = package.allProducts.first { product in
                 product.name == specifiedProduct
             }
@@ -65,7 +65,7 @@ extension ArgumentExtractor {
             }
             
             let supportedSwiftSourceModuleTargets = product.targets.compactMap { target in
-                target as? SwiftSourceModuleTarget
+                target as? SourceModuleTarget
             }
             .filter { swiftSourceModuleTarget in
                 return swiftSourceModuleTarget.kind != .test
@@ -78,7 +78,7 @@ extension ArgumentExtractor {
             return supportedSwiftSourceModuleTargets
         }
         
-        let targets = try specifiedTargets.map { specifiedTarget -> SwiftSourceModuleTarget in
+        let targets = try specifiedTargets.map { specifiedTarget -> SourceModuleTarget in
             let target = package.allTargets.first { target in
                 target.name == specifiedTarget
             }
@@ -90,7 +90,7 @@ extension ArgumentExtractor {
                 )
             }
             
-            guard let swiftSourceModuleTarget = target as? SwiftSourceModuleTarget else {
+            guard let swiftSourceModuleTarget = target as? SourceModuleTarget else {
                 throw ArgumentParsingError.targetIsNotSwiftSourceModule(specifiedTarget)
             }
             

--- a/Plugins/SharedPackagePluginExtensions/ArgumentExtractor+extractSpecifiedTargets.swift
+++ b/Plugins/SharedPackagePluginExtensions/ArgumentExtractor+extractSpecifiedTargets.swift
@@ -12,9 +12,9 @@ import PackagePlugin
 enum ArgumentParsingError: LocalizedError, CustomStringConvertible {
     case unknownProduct(_ productName: String, compatibleProducts: String)
     case unknownTarget(_ targetName: String, compatibleTargets: String)
-    case productDoesNotContainSwiftSourceModuleTargets(String)
-    case packageDoesNotContainSwiftSourceModuleTargets
-    case targetIsNotSwiftSourceModule(String)
+    case productDoesNotContainSourceModuleTargets(String)
+    case packageDoesNotContainSourceModuleTargets
+    case targetIsNotSourceModule(String)
     case testTarget(String)
     
     var description: String {
@@ -31,13 +31,13 @@ enum ArgumentParsingError: LocalizedError, CustomStringConvertible {
                 
                 compatible targets: \(compatibleTargets)
                 """
-        case .productDoesNotContainSwiftSourceModuleTargets(let string):
+        case .productDoesNotContainSourceModuleTargets(let string):
             return "product '\(string)' does not contain any Swift source modules"
-        case .targetIsNotSwiftSourceModule(let string):
+        case .targetIsNotSourceModule(let string):
             return "target '\(string)' is not a Swift source module"
         case .testTarget(let string):
             return "target '\(string)' is a test target; only library and executable targets are supported by Swift-DocC"
-        case .packageDoesNotContainSwiftSourceModuleTargets:
+        case .packageDoesNotContainSourceModuleTargets:
             return "the current package does not contain any compatible Swift source modules"
         }
     }
@@ -64,18 +64,18 @@ extension ArgumentExtractor {
                 )
             }
             
-            let supportedSwiftSourceModuleTargets = product.targets.compactMap { target in
+            let supportedSourceModuleTargets = product.targets.compactMap { target in
                 target as? SourceModuleTarget
             }
-            .filter { swiftSourceModuleTarget in
-                return swiftSourceModuleTarget.kind != .test
+            .filter { sourceModuleTarget in
+                return sourceModuleTarget.kind != .test
             }
             
-            guard !supportedSwiftSourceModuleTargets.isEmpty else {
-                throw ArgumentParsingError.productDoesNotContainSwiftSourceModuleTargets(specifiedProduct)
+            guard !supportedSourceModuleTargets.isEmpty else {
+                throw ArgumentParsingError.productDoesNotContainSourceModuleTargets(specifiedProduct)
             }
             
-            return supportedSwiftSourceModuleTargets
+            return supportedSourceModuleTargets
         }
         
         let targets = try specifiedTargets.map { specifiedTarget -> SourceModuleTarget in
@@ -91,7 +91,7 @@ extension ArgumentExtractor {
             }
             
             guard let swiftSourceModuleTarget = target as? SourceModuleTarget else {
-                throw ArgumentParsingError.targetIsNotSwiftSourceModule(specifiedTarget)
+                throw ArgumentParsingError.targetIsNotSourceModule(specifiedTarget)
             }
             
             guard swiftSourceModuleTarget.kind != .test else {

--- a/Plugins/SharedPackagePluginExtensions/PackageExtensions.swift
+++ b/Plugins/SharedPackagePluginExtensions/PackageExtensions.swift
@@ -68,7 +68,7 @@ extension Package {
     
     /// All targets defined in this package and its dependencies that
     /// can produce documentation.
-    var allDocumentableTargets: [SwiftSourceModuleTarget] {
+    var allDocumentableTargets: [SourceModuleTarget] {
         return allTargets.documentableTargets
     }
     
@@ -83,7 +83,7 @@ extension Package {
     /// All targets defined directly in this package that produce documentation.
     ///
     /// Excludes targets defined in dependencies.
-    var topLevelDocumentableTargets: [SwiftSourceModuleTarget] {
+    var topLevelDocumentableTargets: [SourceModuleTarget] {
         var insertedTargetIds = Set<Target.ID>()
         var topLevelTargets = [Target]()
         
@@ -125,7 +125,7 @@ extension Package {
         return allDocumentableProducts.map(\.name.singleQuoted).joined(separator: ", ")
     }
     
-    func package(for target: SwiftSourceModuleTarget) -> Package? {
+    func package(for target: SourceModuleTarget) -> Package? {
         let possiblePackages = dependencies.map(\.package) + [self]
         
         return possiblePackages.first { package in
@@ -133,7 +133,7 @@ extension Package {
         }
     }
     
-    func containsTarget(_ target: SwiftSourceModuleTarget) -> Bool {
+    func containsTarget(_ target: SourceModuleTarget) -> Bool {
         return targets.contains { packageTarget in
             packageTarget.id == target.id
         }
@@ -141,9 +141,9 @@ extension Package {
 }
 
 private extension Collection where Element == Target {
-    var documentableTargets: [SwiftSourceModuleTarget] {
+    var documentableTargets: [SourceModuleTarget] {
         return compactMap { target in
-            guard let swiftSourceModuleTarget = target as? SwiftSourceModuleTarget else {
+            guard let swiftSourceModuleTarget = target as? SourceModuleTarget else {
                 return nil
             }
             

--- a/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
+++ b/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
@@ -39,7 +39,7 @@ extension PackageManager {
     
     /// Returns the relevant symbols graphs for Swift-DocC documentation generation for the given target.
     func doccSymbolGraphs(
-        for target: SwiftSourceModuleTarget,
+        for target: SourceModuleTarget,
         context: PluginContext,
         verbose: Bool,
         snippetExtractor: SnippetExtractor?,

--- a/Plugins/SharedPackagePluginExtensions/SnippetExtractor+generateSnippetsForTarget.swift
+++ b/Plugins/SharedPackagePluginExtensions/SnippetExtractor+generateSnippetsForTarget.swift
@@ -11,7 +11,7 @@ import PackagePlugin
 
 extension SnippetExtractor {
     func generateSnippets(
-        for target: SwiftSourceModuleTarget,
+        for target: SourceModuleTarget,
         context: PluginContext
     ) throws -> URL? {
         guard let package = context.package.package(for: target) else {

--- a/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
+++ b/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
@@ -8,7 +8,7 @@
 
 import PackagePlugin
 
-extension SwiftSourceModuleTarget {
+extension SourceModuleTarget {
     /// Returns the default options that should be used for generating a symbol graph for the
     /// current target in the given package.
     func defaultSymbolGraphOptions(in package: Package) -> PackageManager.SymbolGraphOptions {

--- a/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
+++ b/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
@@ -18,7 +18,7 @@ import PackagePlugin
         var argumentExtractor = ArgumentExtractor(arguments)
         let specifiedTargets = try argumentExtractor.extractSpecifiedTargets(in: context.package)
         
-        let swiftSourceModuleTargets: [SwiftSourceModuleTarget]
+        let swiftSourceModuleTargets: [SourceModuleTarget]
         if specifiedTargets.isEmpty {
             swiftSourceModuleTargets = context.package.allDocumentableTargets
         } else {

--- a/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
+++ b/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
@@ -21,7 +21,7 @@ import PackagePlugin
         var argumentExtractor = ArgumentExtractor(arguments)
         let specifiedTargets = try argumentExtractor.extractSpecifiedTargets(in: context.package)
         
-        let possibleTargets: [SwiftSourceModuleTarget]
+        let possibleTargets: [SourceModuleTarget]
         if specifiedTargets.isEmpty {
             possibleTargets = context.package.topLevelDocumentableTargets
         } else {


### PR DESCRIPTION
## Summary

With this change you can now treat C/C++ targets through clang in the same way as Swift. They can be included in generated doccarchive and previewed in the same way.

Update the uses of SwiftSourceModuleTarget to use the more general SourceModuleTarget.

## Dependencies

No dependencies on this change. DocC itself can generate documentation for C/C++ symbol graphs.

## Testing

Git clone a package that has a C target, such as the SwiftPM enabled version of libarchive here and run the docc plugin to generate a preview of its documentation.

Steps:
1. `git clone -b vendor-libarchive https://github.com/cmcgee1024/swiftly.git`
2. `cd swiftly/libarchive`
3. Modify the Package.swift file to point to a version of the swift-docc-plugin that permits documentation to be generated for C targets. Add the following package dependency to point to that revision:

```
let package = Package(
    ...
        .executable(
            name: "bsdunzip",
            targets: ["bsdunzip"]
        ),
    ],
    dependencies: [.package(path: "/Users/cmcgee/git/swift-docc-plugin")],   <---- Add this, pointing to the path to the enhanced swift-docc-plugin
```
4. Generate a preview of the `CArchive` target `swift package --disable-sandbox preview-documentation --target CArchive`

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests (looking for suggestions on how to write this test)
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
    - I haven't seen any documentation that assumes a Swift target, so perhaps the documentation is ok? 
