### PR TITLE
Fix backwards compatibility issue with Swift 5.7

### DIFF
--- a/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
+++ b/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
@@ -108,11 +108,7 @@ import PackagePlugin
             }
             
             let archiveOutputPath = archiveOutputDir(for: target)
-            let dependencyArchivePaths: [String] = if isCombinedDocumentationEnabled {
-                task.dependencies.map { archiveOutputDir(for: $0.target) }
-            } else {
-                []
-            }
+            let dependencyArchivePaths: [String] = isCombinedDocumentationEnabled ? task.dependencies.map { archiveOutputDir(for: $0.target) } : []
             
             if verbose {
                 print("documentation archive output path: '\(archiveOutputPath)'")

--- a/Sources/SwiftDocCPluginUtilities/CommandLineArguments/CommandLineArguments.swift
+++ b/Sources/SwiftDocCPluginUtilities/CommandLineArguments/CommandLineArguments.swift
@@ -28,10 +28,10 @@ public struct CommandLineArguments {
     }
     
     /// All remaining (not-yet extracted) options or flags, up to the the first `--` separator (if there is one).
-    private var remainingOptionsOrFlags: [String].SubSequence
+    private var remainingOptionsOrFlags: Array<String>.SubSequence
     
     /// All literals after the first `--` separator (if there is one).
-    private var literalValues: [String].SubSequence
+    private var literalValues: Array<String>.SubSequence
     
     // MARK: Extract
     

--- a/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
+++ b/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
@@ -136,15 +136,16 @@ private extension DocumentedFlag {
             flagListText += " / \(inverseNames.listForHelpDescription)"
         }
         
-        var description = if flagListText.count < 23 {
+        var description: String
+        if flagListText.count < 23 {
             // The flag is short enough to fit the abstract on the same line
-            """
+            description = """
               \(flagListText.padding(toLength: 23, withPad: " ", startingAt: 0)) \(abstract)
             
             """
         } else {
             // The flag is too long to fit the abstract on the same line
-            """
+            description = """
               \(flagListText)
                                       \(abstract)
             


### PR DESCRIPTION
Bug/issue #, if applicable: fixes https://github.com/swiftlang/swift-docc-plugin/issues/94, rdar://134859979

## Summary

swift-docc-plugin was not building with Swift 5.7 due to using newer syntax which did not exist yet.

Fixes the compilation issues by using older Swift syntax.

## Dependencies

N/A

## Testing

Steps:
1. Clone repository and set up docker image with Swift 5.7
2. Try to build swift-docc-plugin and it should fail without these changes, and succeed with them

```
docker run -v /local/path/to/swift-docc-plugin:/swift-docc-plugin -it swift:5.7-amazonlinux2
cd /swift-docc-plugin
swift build
```

Before:

```
/swift-docc-plugin/Plugins/Swift-DocC Convert/Symbolic Links/SwiftDocCPluginUtilities/CommandLineArguments/CommandLineArguments.swift:31:50: error: consecutive declarations on a line must be separated by ';'
    private var remainingOptionsOrFlags: [String].SubSequence
                                                 ^
[...]
/swift-docc-plugin/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift:111:52: error: expected initial value after '='
            let dependencyArchivePaths: [String] = if isCombinedDocumentationEnabled {
                                                   ^
[...]
/swift-docc-plugin/Plugins/Swift-DocC Convert/Symbolic Links/SwiftDocCPluginUtilities/HelpInformation.swift:139:27: error: expected initial value after '='
        var description = if flagListText.count < 23 {
                          ^
```

After:

```
[85/85] Linking snippet-extract
Build complete! (4.95s)
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~~[ ] Added tests~~ Not needed
- [x] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~ Not needed
