### PR TITLE
Fix warnings in Swift 6.2 about non-sendable types in isolated closures

### DIFF
--- a/Sources/SwiftDocCPluginUtilities/BuildGraph/DocumentationBuildGraph.swift
+++ b/Sources/SwiftDocCPluginUtilities/BuildGraph/DocumentationBuildGraph.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A target that can have a documentation task in the build graph
-protocol DocumentationBuildGraphTarget {
+protocol DocumentationBuildGraphTarget: SendableMetatype {
     typealias ID = String
     /// The unique identifier of this target
     var id: ID { get }

--- a/Sources/SwiftDocCPluginUtilities/FoundationExtensions/SendableMetatypeShim.swift
+++ b/Sources/SwiftDocCPluginUtilities/FoundationExtensions/SendableMetatypeShim.swift
@@ -1,0 +1,21 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+// In Swift 6.2, metatypes are no longer sendable by default (SE-0470).
+// Instead a type needs to conform to `SendableMetatype` to indicate that its metatype is sendable.
+//
+// However, `SendableMetatype` doesn't exist before Swift 6.1 so we define an internal alias to `Any` here.
+// This means that conformances to `SendableMetatype` has no effect before 6.2 indicates metatype sendability in 6.2 onwards.
+//
+// Note: Adding a protocol requirement to a _public_ API is a breaking change.
+
+#if compiler(<6.2)
+typealias SendableMetatype = Any
+#endif

--- a/Sources/SwiftDocCPluginUtilities/FoundationExtensions/SendableMetatypeShim.swift
+++ b/Sources/SwiftDocCPluginUtilities/FoundationExtensions/SendableMetatypeShim.swift
@@ -1,12 +1,10 @@
-/*
- This source file is part of the Swift.org open source project
-
- Copyright (c) 2025 Apple Inc. and the Swift project authors
- Licensed under Apache License v2.0 with Runtime Library Exception
-
- See https://swift.org/LICENSE.txt for license information
- See https://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 // In Swift 6.2, metatypes are no longer sendable by default (SE-0470).
 // Instead a type needs to conform to `SendableMetatype` to indicate that its metatype is sendable.

--- a/bin/check-source
+++ b/bin/check-source
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901234]-20[12][8901234]/YEARS/' -e 's/20[12][8901234]/YEARS/'
+    sed -e 's/20[12][789012345]-20[12][89012345]/YEARS/' -e 's/20[12][89012345]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://152474585

## Summary

This resolves a few warnings in Swift 6.2 about non-sendable types in isolated closures.

These changes are all in `internal` API, so we don't need to consider API breaking changes.

## Dependencies

None.

## Testing

Build DocC with a Swift 6.2 compiler. There shouldn't be warnings about "capture of non-sendable type in an isolated closure".

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
